### PR TITLE
Pass array as default value to call to get_option() so we do not get an error…

### DIFF
--- a/alps-fields-converter.php
+++ b/alps-fields-converter.php
@@ -365,7 +365,7 @@ function alps_convert_fields() {
         if ( !$matched_area && $the_theme == 'ALPS for WordPress' || !$matched_area && $the_theme == 'ALPS for Wordpress' ) {
           // WE MUST GRAB EVERY WIDGET AND STICK IT IN wp_inactive_widgets
           //error_log( 'no matched area, so convert existing piklist' );
-          $piklist_widgets  = get_option( 'widget_piklist-universal-widget-theme' );
+          $piklist_widgets  = get_option( 'widget_piklist-universal-widget-theme', []);
           foreach ( $piklist_widgets as $widget_id => $this_widget ) {
             $type = $this_widget['widget'];
             //error_log( 'type: ' . $type );


### PR DESCRIPTION
…if the option does not exist and we try to do a foreach() on the succeeding lines.

_Note: get_option() returns false by default if option does not exist._

If the ALPS fields converter plugin runs on a new WP install that uses v3 ALPS theme, then piklist plugin will not exist so the converter throws errors when it tries to do a conversion. Related to [PR #667 on alps-wordpress](https://github.com/adventistchurch/alps-wordpress/pull/667#issue-1721624714)